### PR TITLE
docs(palettes): Consolidate preview into a single Markdown table

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,101 +16,14 @@ This package is designed to be extensible, allowing developers to register their
 
 This document shows a preview for each available color palette.
 
-
-### monokai
-
-| Color | Hex Code |
-|:---:|:---:|
-| <img src="https://placehold.co/20x20/272822/272822.png" alt="#272822"> | `#272822` |
-| <img src="https://placehold.co/20x20/383d3b/383d3b.png" alt="#383d3b"> | `#383d3b` |
-| <img src="https://placehold.co/20x20/49483e/49483e.png" alt="#49483e"> | `#49483e` |
-| <img src="https://placehold.co/20x20/75715e/75715e.png" alt="#75715e"> | `#75715e` |
-| <img src="https://placehold.co/20x20/a59f85/a59f85.png" alt="#a59f85"> | `#a59f85` |
-| <img src="https://placehold.co/20x20/f92672/f92672.png" alt="#f92672"> | `#f92672` |
-| <img src="https://placehold.co/20x20/a6e22e/a6e22e.png" alt="#a6e22e"> | `#a6e22e` |
-| <img src="https://placehold.co/20x20/f4bf75/f4bf75.png" alt="#f4bf75"> | `#f4bf75` |
-| <img src="https://placehold.co/20x20/66d9ef/66d9ef.png" alt="#66d9ef"> | `#66d9ef` |
-| <img src="https://placehold.co/20x20/ae81ff/ae81ff.png" alt="#ae81ff"> | `#ae81ff` |
-
-
-### pride
-
-| Color | Hex Code |
-|:---:|:---:|
-| <img src="https://placehold.co/20x20/e40303/e40303.png" alt="#e40303"> | `#e40303` |
-| <img src="https://placehold.co/20x20/ff8c00/ff8c00.png" alt="#ff8c00"> | `#ff8c00` |
-| <img src="https://placehold.co/20x20/ffed00/ffed00.png" alt="#ffed00"> | `#ffed00` |
-| <img src="https://placehold.co/20x20/008026/008026.png" alt="#008026"> | `#008026` |
-| <img src="https://placehold.co/20x20/004dff/004dff.png" alt="#004dff"> | `#004dff` |
-| <img src="https://placehold.co/20x20/750787/750787.png" alt="#750787"> | `#750787` |
-| <img src="https://placehold.co/20x20/ffffff/ffffff.png" alt="#ffffff"> | `#ffffff` |
-| <img src="https://placehold.co/20x20/000000/000000.png" alt="#000000"> | `#000000` |
-| <img src="https://placehold.co/20x20/613915/613915.png" alt="#613915"> | `#613915` |
-| <img src="https://placehold.co/20x20/ffafc8/ffafc8.png" alt="#ffafc8"> | `#ffafc8` |
-
-
-### muted
-
-| Color | Hex Code |
-|:---:|:---:|
-| <img src="https://placehold.co/20x20/5a6a62/5a6a62.png" alt="#5a6a62"> | `#5a6a62` |
-| <img src="https://placehold.co/20x20/6e8179/6e8179.png" alt="#6e8179"> | `#6e8179` |
-| <img src="https://placehold.co/20x20/839990/839990.png" alt="#839990"> | `#839990` |
-| <img src="https://placehold.co/20x20/97b1a7/97b1a7.png" alt="#97b1a7"> | `#97b1a7` |
-| <img src="https://placehold.co/20x20/acb9b1/acb9b1.png" alt="#acb9b1"> | `#acb9b1` |
-| <img src="https://placehold.co/20x20/e0e0e0/e0e0e0.png" alt="#e0e0e0"> | `#e0e0e0` |
-| <img src="https://placehold.co/20x20/c7c7c7/c7c7c7.png" alt="#c7c7c7"> | `#c7c7c7` |
-| <img src="https://placehold.co/20x20/aeaeae/aeaeae.png" alt="#aeaeae"> | `#aeaeae` |
-| <img src="https://placehold.co/20x20/959595/959595.png" alt="#959595"> | `#959595` |
-| <img src="https://placehold.co/20x20/7d7d7d/7d7d7d.png" alt="#7d7d7d"> | `#7d7d7d` |
-
-
-### warm
-
-| Color | Hex Code |
-|:---:|:---:|
-| <img src="https://placehold.co/20x20/AF165E/AF165E.png" alt="#AF165E"> | `#AF165E` |
-| <img src="https://placehold.co/20x20/EE092D/EE092D.png" alt="#EE092D"> | `#EE092D` |
-| <img src="https://placehold.co/20x20/FF6302/FF6302.png" alt="#FF6302"> | `#FF6302` |
-| <img src="https://placehold.co/20x20/e96616/e96616.png" alt="#e96616"> | `#e96616` |
-| <img src="https://placehold.co/20x20/D60457/D60457.png" alt="#D60457"> | `#D60457` |
-| <img src="https://placehold.co/20x20/FC9F1B/FC9F1B.png" alt="#FC9F1B"> | `#FC9F1B` |
-| <img src="https://placehold.co/20x20/FFBD27/FFBD27.png" alt="#FFBD27"> | `#FFBD27` |
-| <img src="https://placehold.co/20x20/FFE72B/FFE72B.png" alt="#FFE72B"> | `#FFE72B` |
-| <img src="https://placehold.co/20x20/FCE77D/FCE77D.png" alt="#FCE77D"> | `#FCE77D` |
-| <img src="https://placehold.co/20x20/ffca7b/ffca7b.png" alt="#ffca7b"> | `#ffca7b` |
-
-
-### cool
-
-| Color | Hex Code |
-|:---:|:---:|
-| <img src="https://placehold.co/20x20/09186D/09186D.png" alt="#09186D"> | `#09186D` |
-| <img src="https://placehold.co/20x20/2B3252/2B3252.png" alt="#2B3252"> | `#2B3252` |
-| <img src="https://placehold.co/20x20/3D155F/3D155F.png" alt="#3D155F"> | `#3D155F` |
-| <img src="https://placehold.co/20x20/021c41/021c41.png" alt="#021c41"> | `#021c41` |
-| <img src="https://placehold.co/20x20/4D4C53/4D4C53.png" alt="#4D4C53"> | `#4D4C53` |
-| <img src="https://placehold.co/20x20/8AAAE5/8AAAE5.png" alt="#8AAAE5"> | `#8AAAE5` |
-| <img src="https://placehold.co/20x20/bde8f1/bde8f1.png" alt="#bde8f1"> | `#bde8f1` |
-| <img src="https://placehold.co/20x20/819fa7/819fa7.png" alt="#819fa7"> | `#819fa7` |
-| <img src="https://placehold.co/20x20/CDC6B4/CDC6B4.png" alt="#CDC6B4"> | `#CDC6B4` |
-| <img src="https://placehold.co/20x20/dfe5f3/dfe5f3.png" alt="#dfe5f3"> | `#dfe5f3` |
-
-
-### grayscale
-
-| Color | Hex Code |
-|:---:|:---:|
-| <img src="https://placehold.co/20x20/222222/222222.png" alt="#222222"> | `#222222` |
-| <img src="https://placehold.co/20x20/333333/333333.png" alt="#333333"> | `#333333` |
-| <img src="https://placehold.co/20x20/444444/444444.png" alt="#444444"> | `#444444` |
-| <img src="https://placehold.co/20x20/555555/555555.png" alt="#555555"> | `#555555` |
-| <img src="https://placehold.co/20x20/666666/666666.png" alt="#666666"> | `#666666` |
-| <img src="https://placehold.co/20x20/eeeeee/eeeeee.png" alt="#eeeeee"> | `#eeeeee` |
-| <img src="https://placehold.co/20x20/dddddd/dddddd.png" alt="#dddddd"> | `#dddddd` |
-| <img src="https://placehold.co/20x20/cccccc/cccccc.png" alt="#cccccc"> | `#cccccc` |
-| <img src="https://placehold.co/20x20/bbbbbb/bbbbbb.png" alt="#bbbbbb"> | `#bbbbbb` |
-| <img src="https://placehold.co/20x20/aaaaaa/aaaaaa.png" alt="#aaaaaa"> | `#aaaaaa` |
+| Palette | Colors |
+|:---|:---|
+| `monokai` | <img src="https://placehold.co/20x20/272822/272822.png" alt="#272822" title="#272822"> <img src="https://placehold.co/20x20/383d3b/383d3b.png" alt="#383d3b" title="#383d3b"> <img src="https://placehold.co/20x20/49483e/49483e.png" alt="#49483e" title="#49483e"> <img src="https://placehold.co/20x20/75715e/75715e.png" alt="#75715e" title="#75715e"> <img src="https://placehold.co/20x20/a59f85/a59f85.png" alt="#a59f85" title="#a59f85"> <img src="https://placehold.co/20x20/f92672/f92672.png" alt="#f92672" title="#f92672"> <img src="https://placehold.co/20x20/a6e22e/a6e22e.png" alt="#a6e22e" title="#a6e22e"> <img src="https://placehold.co/20x20/f4bf75/f4bf75.png" alt="#f4bf75" title="#f4bf75"> <img src="https://placehold.co/20x20/66d9ef/66d9ef.png" alt="#66d9ef" title="#66d9ef"> <img src="https://placehold.co/20x20/ae81ff/ae81ff.png" alt="#ae81ff" title="#ae81ff"> |
+| `pride` | <img src="https://placehold.co/20x20/e40303/e40303.png" alt="#e40303" title="#e40303"> <img src="https://placehold.co/20x20/ff8c00/ff8c00.png" alt="#ff8c00" title="#ff8c00"> <img src="https://placehold.co/20x20/ffed00/ffed00.png" alt="#ffed00" title="#ffed00"> <img src="https://placehold.co/20x20/008026/008026.png" alt="#008026" title="#008026"> <img src="https://placehold.co/20x20/004dff/004dff.png" alt="#004dff" title="#004dff"> <img src="https://placehold.co/20x20/750787/750787.png" alt="#750787" title="#750787"> <img src="https://placehold.co/20x20/ffffff/ffffff.png" alt="#ffffff" title="#ffffff"> <img src="https://placehold.co/20x20/000000/000000.png" alt="#000000" title="#000000"> <img src="https://placehold.co/20x20/613915/613915.png" alt="#613915" title="#613915"> <img src="https://placehold.co/20x20/ffafc8/ffafc8.png" alt="#ffafc8" title="#ffafc8"> |
+| `muted` | <img src="https://placehold.co/20x20/5a6a62/5a6a62.png" alt="#5a6a62" title="#5a6a62"> <img src="https://placehold.co/20x20/6e8179/6e8179.png" alt="#6e8179" title="#6e8179"> <img src="https://placehold.co/20x20/839990/839990.png" alt="#839990" title="#839990"> <img src="https://placehold.co/20x20/97b1a7/97b1a7.png" alt="#97b1a7" title="#97b1a7"> <img src="https://placehold.co/20x20/acb9b1/acb9b1.png" alt="#acb9b1" title="#acb9b1"> <img src="https://placehold.co/20x20/e0e0e0/e0e0e0.png" alt="#e0e0e0" title="#e0e0e0"> <img src="https://placehold.co/20x20/c7c7c7/c7c7c7.png" alt="#c7c7c7" title="#c7c7c7"> <img src="https://placehold.co/20x20/aeaeae/aeaeae.png" alt="#aeaeae" title="#aeaeae"> <img src="https://placehold.co/20x20/959595/959595.png" alt="#959595" title="#959595"> <img src="https://placehold.co/20x20/7d7d7d/7d7d7d.png" alt="#7d7d7d" title="#7d7d7d"> |
+| `warm` | <img src="https://placehold.co/20x20/AF165E/AF165E.png" alt="#AF165E" title="#AF165E"> <img src="https://placehold.co/20x20/EE092D/EE092D.png" alt="#EE092D" title="#EE092D"> <img src="https://placehold.co/20x20/FF6302/FF6302.png" alt="#FF6302" title="#FF6302"> <img src="https://placehold.co/20x20/e96616/e96616.png" alt="#e96616" title="#e96616"> <img src="https://placehold.co/20x20/D60457/D60457.png" alt="#D60457" title="#D60457"> <img src="https://placehold.co/20x20/FC9F1B/FC9F1B.png" alt="#FC9F1B" title="#FC9F1B"> <img src="https://placehold.co/20x20/FFBD27/FFBD27.png" alt="#FFBD27" title="#FFBD27"> <img src="https://placehold.co/20x20/FFE72B/FFE72B.png" alt="#FFE72B" title="#FFE72B"> <img src="https://placehold.co/20x20/FCE77D/FCE77D.png" alt="#FCE77D" title="#FCE77D"> <img src="https://placehold.co/20x20/ffca7b/ffca7b.png" alt="#ffca7b" title="#ffca7b"> |
+| `cool` | <img src="https://placehold.co/20x20/09186D/09186D.png" alt="#09186D" title="#09186D"> <img src="https://placehold.co/20x20/2B3252/2B3252.png" alt="#2B3252" title="#2B3252"> <img src="https://placehold.co/20x20/3D155F/3D155F.png" alt="#3D155F" title="#3D155F"> <img src="https://placehold.co/20x20/021c41/021c41.png" alt="#021c41" title="#021c41"> <img src="https://placehold.co/20x20/4D4C53/4D4C53.png" alt="#4D4C53" title="#4D4C53"> <img src="https://placehold.co/20x20/8AAAE5/8AAAE5.png" alt="#8AAAE5" title="#8AAAE5"> <img src="https://placehold.co/20x20/bde8f1/bde8f1.png" alt="#bde8f1" title="#bde8f1"> <img src="https://placehold.co/20x20/819fa7/819fa7.png" alt="#819fa7" title="#819fa7"> <img src="https://placehold.co/20x20/CDC6B4/CDC6B4.png" alt="#CDC6B4" title="#CDC6B4"> <img src="https://placehold.co/20x20/dfe5f3/dfe5f3.png" alt="#dfe5f3" title="#dfe5f3"> |
+| `grayscale` | <img src="https://placehold.co/20x20/222222/222222.png" alt="#222222" title="#222222"> <img src="https://placehold.co/20x20/333333/333333.png" alt="#333333" title="#333333"> <img src="https://placehold.co/20x20/444444/444444.png" alt="#444444" title="#444444"> <img src="https://placehold.co/20x20/555555/555555.png" alt="#555555" title="#555555"> <img src="https://placehold.co/20x20/666666/666666.png" alt="#666666" title="#666666"> <img src="https://placehold.co/20x20/eeeeee/eeeeee.png" alt="#eeeeee" title="#eeeeee"> <img src="https://placehold.co/20x20/dddddd/dddddd.png" alt="#dddddd" title="#dddddd"> <img src="https://placehold.co/20x20/cccccc/cccccc.png" alt="#cccccc" title="#cccccc"> <img src="https://placehold.co/20x20/bbbbbb/bbbbbb.png" alt="#bbbbbb" title="#bbbbbb"> <img src="https://placehold.co/20x20/aaaaaa/aaaaaa.png" alt="#aaaaaa" title="#aaaaaa"> |
 
 ## 🖼️ Available Styles & Palettes
 

--- a/scripts/generate-palettes-preview.ts
+++ b/scripts/generate-palettes-preview.ts
@@ -18,13 +18,13 @@ function createPalettePreview() {
   console.log('Generating color palette previews...');
 
   let htmlSections = '';
-  let markdownSections = '';
+  let markdownTableRows = '';
 
   // --- Main Loop for Generating HTML and Markdown ---
   allPalettes.forEach((palette) => {
     const colors = [...palette.colors];
 
-    // --- HTML Generation ---
+    // --- HTML Generation (Remains the same) ---
     let swatchesHtml = '';
     colors.forEach((color) => {
       swatchesHtml += `
@@ -44,20 +44,17 @@ function createPalettePreview() {
       </section>
     `;
 
-    // --- Markdown Generation ---
-    let markdownTable = `| Color | Hex Code |\n|:---:|:---:|\n`;
-    colors.forEach((color) => {
-      const swatchImage = `<img src="https://placehold.co/20x20/${color.substring(
-        1
-      )}/${color.substring(1)}.png" alt="${color}">`;
-      markdownTable += `| ${swatchImage} | \`${color}\` |\n`;
-    });
+    // --- Markdown Generation (Refactored for a single table) ---
+    const markdownSwatches = colors
+      .map(
+        (color) =>
+          `<img src="https://placehold.co/20x20/${color.substring(
+            1
+          )}/${color.substring(1)}.png" alt="${color}" title="${color}">`
+      )
+      .join(' ');
 
-    markdownSections += `
-### ${palette.name}
-
-${markdownTable}
-`;
+    markdownTableRows += `| \`${palette.name}\` | ${markdownSwatches} |\n`;
   });
 
   // --- Assemble and Write HTML File ---
@@ -96,7 +93,7 @@ ${markdownTable}
   );
 
   // --- Assemble and Write Markdown File ---
-  const markdownContent = `## 🎨 Available Color Palettes\n\nThis document shows a preview for each available color palette.\n\n${markdownSections}`;
+  const markdownContent = `## 🎨 Available Color Palettes\n\nThis document shows a preview for each available color palette.\n\n| Palette | Colors |\n|:---|:---|\n${markdownTableRows}`;
   const mdOutputPath = path.join(process.cwd(), MD_OUTPUT_FILE);
   fs.writeFileSync(mdOutputPath, markdownContent);
   console.log(`✅ Markdown palette preview generated! See ${MD_OUTPUT_FILE}.`);


### PR DESCRIPTION
Refactors the `generate-palettes-preview.ts` script to generate a single, unified Markdown table for all color palettes.

Previously, the script created a separate heading and table for each palette, which made the `PALETTES.md` file long and difficult to scan. This change improves readability by presenting all palettes in a more compact and comparable format. The HTML preview generation remains unchanged.